### PR TITLE
Adicionando JsonPropertyName às classes do Shared.Pagination

### DIFF
--- a/Shared.Pagination/Abstract/GetFuncionariosOptions.cs
+++ b/Shared.Pagination/Abstract/GetFuncionariosOptions.cs
@@ -10,15 +10,19 @@ namespace Shared.Pagination.Abstract
     public abstract record class GetFuncionariosOptions: GetIntegranteOptions
     {
         [FromQuery(Name = "prefixo_cargo")]
+        [JsonPropertyName("prefixo_cargo")]
         public string? PrefixoCargo { get; init; }
 
         [FromQuery(Name = "status")]
+        [JsonPropertyName("status")]
         public int? Status { get; init; }
 
         [FromQuery(Name = "salario_minimo")]
+        [JsonPropertyName("salario_minimo")]
         public decimal SalarioMinimo { get; init; } = 0;
 
         [FromQuery(Name = "salario_maximo")]
+        [JsonPropertyName("salario_maximo")]
         public decimal SalarioMaximo { get; init; } = decimal.MaxValue;
     }
 }

--- a/Shared.Pagination/Abstract/GetIntegranteOptions.cs
+++ b/Shared.Pagination/Abstract/GetIntegranteOptions.cs
@@ -10,9 +10,11 @@ namespace Shared.Pagination.Abstract
     public abstract record class GetIntegranteOptions: GetOptions
     {
         [FromQuery(Name = "prefixo_name")]
+        [JsonPropertyName("prefixo_name")]
         public string? PrefixoName { get; init; }
 
         [FromQuery(Name = "incluir_endereco")]
+        [JsonPropertyName("incluir_endereco")]
         public bool IncluirEndereco { get; init; } = false;
     }
 }

--- a/Shared.Pagination/Abstract/GetOptions.cs
+++ b/Shared.Pagination/Abstract/GetOptions.cs
@@ -12,9 +12,11 @@ namespace Shared.Pagination.Abstract
         private int limiteDeResultados = 10;
 
         [FromQuery(Name = "comeco")]
+        [JsonPropertyName("comeco")]
         public int ComecarApartirDe { get; init; } = 0;
 
         [FromQuery(Name = "limite")]
+        [JsonPropertyName("limite")]
         public int LimiteDeResultados 
         { 
             get => limiteDeResultados;
@@ -25,9 +27,11 @@ namespace Shared.Pagination.Abstract
         }
 
         [FromQuery(Name = "ordenacao")]
+        [JsonPropertyName("ordenacao")]
         public string? Ordenacao { get; init; }
 
         [FromQuery(Name = "crescente")]
+        [JsonPropertyName("crescente")]
         public bool Crescente { get; init; } = true;
     }
 }

--- a/Shared.Pagination/GetAdministrativoOptions.cs
+++ b/Shared.Pagination/GetAdministrativoOptions.cs
@@ -10,6 +10,7 @@ namespace Shared.Pagination
     public record class GetAdministrativoOptions
     {
         [FromQuery(Name = "incluir_endereco")]
+        [JsonPropertyName("incluir_endereco")]
         public bool IncluirEndereco { get; init; } = false;
     }
 }

--- a/Shared.Pagination/GetAlunoOptions.cs
+++ b/Shared.Pagination/GetAlunoOptions.cs
@@ -10,12 +10,15 @@ namespace Shared.Pagination
     public record class GetAlunoOptions
     {
         [FromQuery(Name = "incluir_turmas")]
+        [JsonPropertyName("incluir_turmas")]
         public bool IncluirTurmas { get; init; } = false;
 
         [FromQuery(Name = "incluir_media")]
+        [JsonPropertyName("incluir_media")]
         public bool IncluirMedia { get; init; } = false;
 
         [FromQuery(Name = "incluir_endereco")]
+        [JsonPropertyName("incluir_endereco")]
         public bool IncluirEndereco { get; init; } = false;
     }
 }

--- a/Shared.Pagination/GetAlunoTurmaOptions.cs
+++ b/Shared.Pagination/GetAlunoTurmaOptions.cs
@@ -10,6 +10,7 @@ namespace Shared.Pagination
     public record class GetAlunoTurmaOptions
     {
         [FromQuery(Name = "incluir_aluno")]
+        [JsonPropertyName("incluir_aluno")]
         public bool IncluirAluno { get; init; } = false;
     }
 }

--- a/Shared.Pagination/GetAlunosOptions.cs
+++ b/Shared.Pagination/GetAlunosOptions.cs
@@ -11,12 +11,15 @@ namespace Shared.Pagination
     public record class GetAlunosOptions: GetIntegranteOptions
     {
         [FromQuery(Name = "ano_escolar")]
+        [JsonPropertyName("ano_escolar")]
         public int? AnoEscolar { get; init; }
 
         [FromQuery(Name = "turno")]
+        [JsonPropertyName("turno")]
         public int? Turno { get; init; }
 
         [FromQuery(Name = "incluir_turmas")]
+        [JsonPropertyName("incluir_turmas")]
         public bool IncluirTurmas { get; init; } = false;
     } 
 } 

--- a/Shared.Pagination/GetProfessorOptions.cs
+++ b/Shared.Pagination/GetProfessorOptions.cs
@@ -10,9 +10,11 @@ namespace Shared.Pagination
     public record class GetProfessorOptions
     {
         [FromQuery(Name = "incluir_turmas")]
+        [JsonPropertyName("incluir_turmas")]
         public bool IncluirTurmas { get; init; } = false;
 
         [FromQuery(Name = "incluir_endereco")]
+        [JsonPropertyName("incluir_endereco")]
         public bool IncluirEndereco { get; init; } = false;
     }
 } 

--- a/Shared.Pagination/GetProfessoresOptions.cs
+++ b/Shared.Pagination/GetProfessoresOptions.cs
@@ -11,6 +11,7 @@ namespace Shared.Pagination
     public record class GetProfessoresOptions: GetFuncionariosOptions
     {
         [FromQuery(Name = "incluir_turmas")]
+        [JsonPropertyName("incluir_turmas")]
         public bool IncluirTurmas { get; init; } = false;
     }
 }

--- a/Shared.Pagination/GetTurmaOptions.cs
+++ b/Shared.Pagination/GetTurmaOptions.cs
@@ -10,9 +10,11 @@ namespace Shared.Pagination
     public record class GetTurmaOptions
     {
         [FromQuery(Name = "incluir_alunos")]
+        [JsonPropertyName("incluir_alunos")]
         public bool IncluirAlunos { get; init; } = false;
 
         [FromQuery(Name = "incluir_professor")]
+        [JsonPropertyName("incluir_professor")]
         public bool IncluirProfessor { get; init; } = false;
     }
 }

--- a/Shared.Pagination/GetTurmasOptions.cs
+++ b/Shared.Pagination/GetTurmasOptions.cs
@@ -11,21 +11,27 @@ namespace Shared.Pagination
     public record class GetTurmasOptions: GetOptions
     {
         [FromQuery(Name = "prefixo_disciplina")]
+        [JsonPropertyName("prefixo_disciplina")]
         public string? PrefixoDisciplina { get; init; }
 
         [FromQuery(Name = "ano_escolar")]
+        [JsonPropertyName("ano_escolar")]
         public int? AnoEscolar { get; init; }
 
         [FromQuery(Name = "a_partir_data")]
+        [JsonPropertyName("a_partir_data")]
         public DateTime ApartirData { get; init; } = DateTime.MinValue;
 
         [FromQuery(Name = "ate_data")]
+        [JsonPropertyName("ate_data")]
         public DateTime AteData { get; init; } = DateTime.MaxValue;
 
         [FromQuery(Name = "incluir_alunos")]
+        [JsonPropertyName("incluir_alunos")]
         public bool IncluirAlunos { get; init; } = false;
 
         [FromQuery(Name = "incluir_professor")]
+        [JsonPropertyName("incluir_professor")]
         public bool IncluirProfessor { get; init; } = false;
     }
 }

--- a/Shared.Pagination/GetUsuarioAdministrativoOptions.cs
+++ b/Shared.Pagination/GetUsuarioAdministrativoOptions.cs
@@ -11,9 +11,11 @@ namespace Shared.Pagination
     public class GetUsuarioAdministrativoOptions
     {
         [FromQuery(Name = "incluir_administrativo")]
+        [JsonPropertyName("incluir_administrativo")]
         public required bool IncluirAdministrativo { get; set; }
 
         [FromQuery(Name = "incluir_endereco")]
+        [JsonPropertyName("incluir_endereco")]
         public required bool IncluirEndereco { get; set; }
     }
 }

--- a/Shared.Pagination/GetUsuarioAlunoOptions.cs
+++ b/Shared.Pagination/GetUsuarioAlunoOptions.cs
@@ -11,12 +11,15 @@ namespace Shared.Pagination
     public class GetUsuarioAlunoOptions
     {
         [FromQuery(Name = "incluir_aluno")]
+        [JsonPropertyName("incluir_aluno")]
         public required bool IncluirAluno { get; set; }
 
         [FromQuery(Name = "incluir_endereco")]
+        [JsonPropertyName("incluir_endereco")]
         public required bool IncluirEndereco { get; set; }
 
         [FromQuery(Name = "incluir_turma")]
+        [JsonPropertyName("incluir_turma")]
         public required bool IncluirTurma {  get; set; }
     }
 }

--- a/Shared.Pagination/GetUsuarioProfessorOptions.cs
+++ b/Shared.Pagination/GetUsuarioProfessorOptions.cs
@@ -11,9 +11,11 @@ namespace Shared.Pagination
     public class GetUsuarioProfessorOptions
     {
         [FromQuery(Name = "incluir_professor")]
+        [JsonPropertyName("incluir_professor")]
         public required bool IncluirProfessor {  get; set; }
 
         [FromQuery(Name = "incluir_endereco")]
+        [JsonPropertyName("incluir_endereco")]
         public required bool IncluirEndereco { get; set; }
     }
 }


### PR DESCRIPTION
O data annotation JsonPropertyName foi adicionado às classes do Shared.Pagination que são passadas com argumentos de query para dar match entre o nome do parâmetro com o nome retornado pelo UnprocessableEntity quando a classe falha na validação do controlador